### PR TITLE
Improve the handling of age.var and id.vars within charlson comorbidities

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: medicalcoder
 Title: A Unified and Longitudinally Aware Framework for ICD-Based Comorbidity Assessment
-Version: 0.8.0
+Version: 0.8.0.9000
 Authors@R: c(
     person(given = "Peter",   family = "DeWitt",    email = "peter.dewitt@cuanschutz.edu",      role = c("aut", "cre", "cov"), comment = c(ORCID = "0000-0002-6391-0795")),
     person(given = "Tell",    family = "Bennett",   email = "tell.bennett@cuanschutz.edu",      role = c("ctb"),               comment = c(ORCID = "0000-0003-1483-4236")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# medicalcoder 0.8.0.9000
+
+## Bug Fixes
+
+* Fix Charlson `age.var` handling when `id.vars` is missing or has multiple ages
+  per ID. (#43)
+
 # medicalcoder 0.8.0
 
 ## License Change

--- a/R/comorbidities.R
+++ b/R/comorbidities.R
@@ -571,11 +571,29 @@ comorbidities.data.frame <- function(data,
   } else if (startsWith(method, "charlson")) {
     ccc <- .charlson(id.vars = id.vars, iddf = iddf, cmrb = cmrb, primarydx.var = primarydx.var, method = method)
     if (!is.null(age.var)) {
-      ages <- mdcr_unique(mdcr_select(data, cols = c(id.vars, age.var)))
+      if (id.vars.created) {
+        ages <- mdcr_unique(mdcr_select(data, cols = c(age.var)))
+        ages <- mdcr_set(ages, j = id.vars, value = rep(1L, nrow(ages)))
+        warn_about_age <- nrow(ages) > 1
+      } else {
+        ages <- mdcr_unique(mdcr_select(data, cols = c(id.vars, age.var)))
+        warn_about_age <- any(mdcr_duplicated(ages, by = id.vars))
+      }
+
+      if (warn_about_age) {
+        if (id.vars.created) {
+          msg <- "There is more than one unique value for age.  Since `id.vars = NULL` the expectation is there would be one unique age value.  The return will have more than one row, one for each unique age."
+        } else {
+          msg <- "There is at least one set of id.vars with more than one age value.  The expectation is that there is only one age value for each unique set of id.vars.  The return will have more than one row for each unique set of id.vars."
+        }
+        warning(msg, call. = FALSE)
+      }
+
       ages[["age_score"]] <- as.integer(cut(ages[[age.var]], breaks = c(-Inf, 50, 60, 70, 80, Inf), right = TRUE)) - 1L
       ccc <- merge(ccc, mdcr_select(ages, cols = c(id.vars, "age_score")), all.x = TRUE, by = id.vars, sort = FALSE)
       nonmissing <- which(!is.na(ccc[["age_score"]]))
       ccc[["cci"]][nonmissing] <- ccc[["cci"]][nonmissing] + ccc[["age_score"]][nonmissing]
+
     } else {
       ccc[["age_score"]] <- rep(NA_integer_, nrow(ccc))
     }

--- a/tests/test-comorbidities.R
+++ b/tests/test-comorbidities.R
@@ -363,5 +363,66 @@ for (m in ms) {
 }
 
 ################################################################################
+# age.var handling for charlson with missing/ambiguous id.vars
+#
+# RE: https://github.com/dewittpe/medicalcoder/issues/43
+DF <-
+  data.frame(
+    pid = c(1, 1, 2),
+    enc_id = c(1, 2, 1),
+    icd_code = c("", "", ""),
+    age = c(54, 55, 54),
+    stringsAsFactors = FALSE
+  )
+
+common_args <-
+  list(
+    data      = DF,
+    icd.codes = "icd_code",
+    poa       = 1L,
+    primarydx = 0L,
+    method    = "charlson_quan2005"
+  )
+
+# id.vars = NULL should not error when age.var is supplied
+# for v0.8.0 this would error.
+out_no_error <-
+  tryCatchError(
+    suppressWarnings(
+      do.call(comorbidities, c(common_args, list(id.vars = NULL, age.var = "age")))
+    )
+  )
+stopifnot(inherits(out_no_error, "medicalcoder_comorbidities"), nrow(out_no_error) == 2L)
+
+# if id.vars = NULL, or id.vars = "ptid", for the example, data, the return will
+# have three rows becuase the ages are distinct.  This should give a warning
+out0_warning <-
+  tryCatchWarning(
+    do.call(comorbidities, c(common_args, list(id.vars = NULL, age.var = "age")))
+  )
+out1_warning <-
+  tryCatchWarning(
+    do.call(comorbidities, c(common_args, list(id.vars = "pid", age.var = "age")))
+  )
+stopifnot(inherits(out0_warning, "warning"), inherits(out1_warning, "warning"))
+stopifnot(
+  out0_warning$message == "There is more than one unique value for age.  Since `id.vars = NULL` the expectation is there would be one unique age value.  The return will have more than one row, one for each unique age.",
+  out1_warning$message == "There is at least one set of id.vars with more than one age value.  The expectation is that there is only one age value for each unique set of id.vars.  The return will have more than one row for each unique set of id.vars."
+)
+
+out0 <-
+  suppressWarnings(
+    do.call(comorbidities, c(common_args, list(id.vars = NULL, age.var = "age")))
+  )
+out1 <-
+  suppressWarnings(
+    do.call(comorbidities, c(common_args, list(id.vars = "pid", age.var = "age")))
+  )
+stopifnot(
+  inherits(out0, "medicalcoder_comorbidities"), nrow(out0) == 2L,
+  inherits(out1, "medicalcoder_comorbidities"), nrow(out1) == 3L
+)
+
+################################################################################
 #                                 End of File                                  #
 ################################################################################


### PR DESCRIPTION
Prior to this change when Charlson comorbidities were requested and id.vars was NULL and age.var was not NULL then there would be an error as the merge to add the age scores onto the results.  When there was more than one age value for a unique id.var, the return will have more than one row for the id.var.  This is conceptually bad.

This change adds to tests/test-comorbidites.R to check for warning messages and expected returns when the id.vars are not one-to-one with c(id.vars, age.var)  These changes make sure the error does not occur. Warnings are thrown when there is more than one age for the id.vars

fix #43